### PR TITLE
Rebuild with TempestRemap 2.0.2

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,12 +2,12 @@
 set -e
 set -x
 
-if [[ ! -z "$mpi" && "$mpi" != "nompi" ]]; then
+if [[ -n "$mpi" && "$mpi" != "nompi" ]]; then
   export CONFIGURE_ARGS="CC=mpicc CXX=mpic++ F77=mpif77 FC=mpif90 F90=mpif90 --with-mpi=${PREFIX} ${CONFIGURE_ARGS}"
 fi
 
-if [[ ! -z "$tempest" && "$tempest" != "notempest" ]]; then
-  export CONFIGURE_ARGS="--with-tempestremap=${PREFIX} --with-eigen3=${PREFIX} ${CONFIGURE_ARGS}"
+if [[ -n "$tempest" && "$tempest" != "notempest" ]]; then
+  export CONFIGURE_ARGS="--with-tempestremap=${PREFIX} --with-eigen3=${PREFIX}/include/eigen3 --with-netcdf=${PREFIX} ${CONFIGURE_ARGS}"
 fi
 
 autoreconf -fi

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ if [[ -n "$mpi" && "$mpi" != "nompi" ]]; then
 fi
 
 if [[ -n "$tempest" && "$tempest" != "notempest" ]]; then
-  export CONFIGURE_ARGS="--with-tempestremap=${PREFIX} --with-eigen3=${PREFIX}/include/eigen3 --with-netcdf=${PREFIX} ${CONFIGURE_ARGS}"
+  export CONFIGURE_ARGS="--with-tempestremap=${PREFIX} --with-eigen3=${PREFIX}/include/eigen3 --with-netcdf=${PREFIX} --with-netcdf-cxx=${PREFIX} ${CONFIGURE_ARGS}"
 fi
 
 autoreconf -fi
@@ -24,4 +24,5 @@ if [ "$(uname)" == "Linux" ]; then
   make check \
     || { cat itaps/imesh/test-suite.log; exit 1; }
 fi
+
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ build:
     - {{ name }} * {{ mpi_prefix }}_*
   {% endif %}
 
-  skip: True  # [win]
+  skip: True  # [win or ((tempest == 'tempest') and (osx or (linux and (mpi == 'nompi'))))]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ build:
     - {{ name }} * {{ mpi_prefix }}_*
   {% endif %}
 
-  skip: True  # [win or ((tempest == 'tempest') and (osx or (linux and (mpi == 'nompi'))))]
+  skip: True  # [win or ((tempest == 'tempest') and (mpi == 'nompi'))]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "moab" %}
 {% set version = "5.1.0" %}
 {% set sha256 = "0371fc25d2594589e95700739f01614f097b6157fb6023ed8995e582726ca658" %}
-{% set build = 7 %}
+{% set build = 8 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -59,9 +59,6 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
     - openssh  # [mpi == 'openmpi']
-    - tempest-remap  # [tempest == 'tempest']
-    - libnetcdf * {{ mpi_prefix }}_*  # [tempest == 'tempest']
-    - eigen  # [tempest == 'tempest']
   host:
     - libblas
     - libcblas
@@ -71,8 +68,10 @@ requirements:
     - setuptools
     - cython
     - {{ mpi }}  # [mpi != 'nompi']
-    - tempest-remap  # [tempest == 'tempest']
+    - tempest-remap 2.0.2  # [tempest == 'tempest']
     - libnetcdf * {{ mpi_prefix }}_*  # [tempest == 'tempest']
+    - eigen  # [tempest == 'tempest']
+    - netcdf-cxx-legacy  # [tempest == 'tempest']
   run:
     - python
     - hdf5 * {{ mpi_prefix }}_*
@@ -80,8 +79,9 @@ requirements:
     - setuptools
     - {{ mpi }}  # [mpi != 'nompi']
     - openssh  # [mpi == 'openmpi']
-    - tempest-remap  # [tempest == 'tempest']
+    - tempest-remap 2.0.2  # [tempest == 'tempest']
     - libnetcdf * {{ mpi_prefix }}_*  # [tempest == 'tempest']
+    - netcdf-cxx-legacy  # [tempest == 'tempest']
 
 test:
   source_files:
@@ -93,6 +93,7 @@ test:
     - test -f ${PREFIX}/lib/libMOAB.so  # [linux]
     - test -f ${PREFIX}/lib/libMOAB.dylib  # [osx]
     - python examples/python/laplaciansmoother.py MeshFiles/unittest/surfrandomtris-4part.h5m 25
+    - mbtempest --help  # [tempest == 'tempest']
 
 about:
   home: http://press3.mcs.anl.gov/sigma/moab-library/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,11 @@ build:
     - {{ name }} * {{ mpi_prefix }}_*
   {% endif %}
 
-  skip: True  # [win or ((tempest == 'tempest') and (mpi == 'nompi'))]
+  # Since this logic is a little hard to parse, skip if:
+  # * windows
+  # * tempest and OSX (clang isn't happy)
+  # * tempest and MPI and linux (current release doesn't support tempest in serial)
+  skip: True  # [win or ((tempest == 'tempest') and (osx or (linux and (mpi == 'nompi'))))]
 
 requirements:
   build:


### PR DESCRIPTION
This version of moab is not compatible with 2.0.3, the latest
release.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #24 
