### PR TITLE
Update package versions related to MPI build matrix

### DIFF
--- a/.ci_support/linux_mpimpichpython2.7tempestnotempest.yaml
+++ b/.ci_support/linux_mpimpichpython2.7tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpimpichpython2.7tempesttempest.yaml
+++ b/.ci_support/linux_mpimpichpython2.7tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.6tempestnotempest.yaml
+++ b/.ci_support/linux_mpimpichpython3.6tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.6tempesttempest.yaml
+++ b/.ci_support/linux_mpimpichpython3.6tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.7tempestnotempest.yaml
+++ b/.ci_support/linux_mpimpichpython3.7tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.7tempesttempest.yaml
+++ b/.ci_support/linux_mpimpichpython3.7tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.8tempestnotempest.yaml
+++ b/.ci_support/linux_mpimpichpython3.8tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpimpichpython3.8tempesttempest.yaml
+++ b/.ci_support/linux_mpimpichpython3.8tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - mpich
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython2.7tempestnotempest.yaml
+++ b/.ci_support/linux_mpinompipython2.7tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython2.7tempesttempest.yaml
+++ b/.ci_support/linux_mpinompipython2.7tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython3.6tempestnotempest.yaml
+++ b/.ci_support/linux_mpinompipython3.6tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython3.6tempesttempest.yaml
+++ b/.ci_support/linux_mpinompipython3.6tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython3.7tempestnotempest.yaml
+++ b/.ci_support/linux_mpinompipython3.7tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython3.7tempesttempest.yaml
+++ b/.ci_support/linux_mpinompipython3.7tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython3.8tempestnotempest.yaml
+++ b/.ci_support/linux_mpinompipython3.8tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpinompipython3.8tempesttempest.yaml
+++ b/.ci_support/linux_mpinompipython3.8tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - nompi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython2.7tempestnotempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython2.7tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython2.7tempesttempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython2.7tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.6tempestnotempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.6tempesttempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.6tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.7tempestnotempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.7tempesttempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.7tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.8tempestnotempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.8tempestnotempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/linux_mpiopenmpipython3.8tempesttempest.yaml
+++ b/.ci_support/linux_mpiopenmpipython3.8tempesttempest.yaml
@@ -16,15 +16,21 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:
 - 3.8 *netlib
+libnetcdf:
+- 4.7.1
 mpi:
 - openmpi
 numpy:
 - '1.14'
 pin_run_as_build:
+  libnetcdf:
+    max_pin: x.x.x
   python:
     min_pin: x.x
     max_pin: x.x

--- a/.ci_support/osx_mpimpichpython2.7tempestnotempest.yaml
+++ b/.ci_support/osx_mpimpichpython2.7tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpimpichpython2.7tempesttempest.yaml
+++ b/.ci_support/osx_mpimpichpython2.7tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpimpichpython3.6tempestnotempest.yaml
+++ b/.ci_support/osx_mpimpichpython3.6tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpimpichpython3.6tempesttempest.yaml
+++ b/.ci_support/osx_mpimpichpython3.6tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpimpichpython3.7tempestnotempest.yaml
+++ b/.ci_support/osx_mpimpichpython3.7tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpimpichpython3.7tempesttempest.yaml
+++ b/.ci_support/osx_mpimpichpython3.7tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpimpichpython3.8tempestnotempest.yaml
+++ b/.ci_support/osx_mpimpichpython3.8tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpimpichpython3.8tempesttempest.yaml
+++ b/.ci_support/osx_mpimpichpython3.8tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython2.7tempestnotempest.yaml
+++ b/.ci_support/osx_mpinompipython2.7tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython2.7tempesttempest.yaml
+++ b/.ci_support/osx_mpinompipython2.7tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython3.6tempestnotempest.yaml
+++ b/.ci_support/osx_mpinompipython3.6tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython3.6tempesttempest.yaml
+++ b/.ci_support/osx_mpinompipython3.6tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython3.7tempestnotempest.yaml
+++ b/.ci_support/osx_mpinompipython3.7tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython3.7tempesttempest.yaml
+++ b/.ci_support/osx_mpinompipython3.7tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython3.8tempestnotempest.yaml
+++ b/.ci_support/osx_mpinompipython3.8tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpinompipython3.8tempesttempest.yaml
+++ b/.ci_support/osx_mpinompipython3.8tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython2.7tempestnotempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython2.7tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython2.7tempesttempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython2.7tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython3.6tempestnotempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.6tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython3.6tempesttempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.6tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython3.7tempestnotempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.7tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython3.7tempesttempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.7tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython3.8tempestnotempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.8tempestnotempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/.ci_support/osx_mpiopenmpipython3.8tempesttempest.yaml
+++ b/.ci_support/osx_mpiopenmpipython3.8tempesttempest.yaml
@@ -16,6 +16,8 @@ fortran_compiler:
 - gfortran
 fortran_compiler_version:
 - '7'
+hdf5:
+- 1.10.5
 libblas:
 - 3.8 *netlib
 libcblas:

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,7 +85,7 @@ requirements:
     - {{ mpi }}  # [mpi != 'nompi']
     - openssh  # [mpi == 'openmpi']
     - libnetcdf * {{ mpi_prefix }}_*  # [tempest == 'tempest']
-    - netcdf-cxx-legacy * {{ mpi_prefix }}_* # [tempest == 'tempest']
+    - netcdf-cxx-legacy * {{ mpi_prefix }}_*  # [tempest == 'tempest']
     - tempest-remap 2.0.2 {{ mpi_prefix }}_*  # [tempest == 'tempest']
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "moab" %}
 {% set version = "5.1.0" %}
 {% set sha256 = "0371fc25d2594589e95700739f01614f097b6157fb6023ed8995e582726ca658" %}
-{% set build = 8 %}
+{% set build = 9 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -49,11 +49,7 @@ build:
     - {{ name }} * {{ mpi_prefix }}_*
   {% endif %}
 
-  # Since this logic is a little hard to parse, skip if:
-  # * windows
-  # * tempest and OSX (clang isn't happy)
-  # * tempest and MPI and linux (current release doesn't support tempest in serial)
-  skip: True  # [win or ((tempest == 'tempest') and (osx or (linux and (mpi == 'nompi'))))]
+  skip: True  # [win or (osx and (tempest == 'tempest')) or (linux and  and (tempest == 'tempest') and (mpi == 'nompi'))]
 
 requirements:
   build:
@@ -67,15 +63,20 @@ requirements:
     - libblas
     - libcblas
     - python
+    # need to list hdf5, libnetcdf and netcdf-cxx-legacy twice to get version
+    # pinning from conda_build_config and build pinning from {{ mpi_prefix }}
+    - hdf5
     - hdf5 * {{ mpi_prefix }}_*
     - numpy
     - setuptools
     - cython
     - {{ mpi }}  # [mpi != 'nompi']
-    - tempest-remap 2.0.2  # [tempest == 'tempest']
+    - libnetcdf  # [tempest == 'tempest']
     - libnetcdf * {{ mpi_prefix }}_*  # [tempest == 'tempest']
-    - eigen  # [tempest == 'tempest']
     - netcdf-cxx-legacy  # [tempest == 'tempest']
+    - netcdf-cxx-legacy * {{ mpi_prefix }}_*  # [tempest == 'tempest']
+    - eigen  # [tempest == 'tempest']
+    - tempest-remap 2.0.2 {{ mpi_prefix }}_*  # [tempest == 'tempest']
   run:
     - python
     - hdf5 * {{ mpi_prefix }}_*
@@ -83,9 +84,9 @@ requirements:
     - setuptools
     - {{ mpi }}  # [mpi != 'nompi']
     - openssh  # [mpi == 'openmpi']
-    - tempest-remap 2.0.2  # [tempest == 'tempest']
     - libnetcdf * {{ mpi_prefix }}_*  # [tempest == 'tempest']
-    - netcdf-cxx-legacy  # [tempest == 'tempest']
+    - netcdf-cxx-legacy * {{ mpi_prefix }}_* # [tempest == 'tempest']
+    - tempest-remap 2.0.2 {{ mpi_prefix }}_*  # [tempest == 'tempest']
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,7 @@ build:
     - {{ name }} * {{ mpi_prefix }}_*
   {% endif %}
 
-  skip: True  # [win or (osx and (tempest == 'tempest')) or (linux and  and (tempest == 'tempest') and (mpi == 'nompi'))]
+  skip: True  # [win or (osx and (tempest == 'tempest')) or (linux and (tempest == 'tempest') and (mpi == 'nompi'))]
 
 requirements:
   build:


### PR DESCRIPTION
Packages need to be listed twice to get the right pinnings from conda-smithy.  `netcdf-cxx-legacy` and `tempest-remap` have now been build with the appropriate versions of `libnetcdf` and `hdf5`, so
they are also pinned for consistently.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
