### PR TITLE
Enable tempest-remap for OSX

### DIFF
--- a/.ci_support/linux_64_mpimpichnumpy1.16python3.6.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.16python3.6.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpimpichnumpy1.16python3.6.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.16python3.6.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpimpichnumpy1.16python3.7.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.16python3.7.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpimpichnumpy1.16python3.7.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.16python3.7.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpimpichnumpy1.16python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.16python3.8.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpimpichnumpy1.16python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.16python3.8.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpimpichnumpy1.19python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.19python3.9.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpimpichnumpy1.19python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.19python3.9.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.16python3.6.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.16python3.6.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.16python3.6.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.16python3.6.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.16python3.7.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.16python3.7.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.16python3.7.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.16python3.7.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.16python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.16python3.8.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.16python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.16python3.8.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.19python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.19python3.9.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpinompinumpy1.19python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.19python3.9.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.16python3.6.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.16python3.6.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.16python3.6.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.16python3.6.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.16python3.7.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.16python3.7.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.16python3.7.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.16python3.7.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.16python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.16python3.8.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.16python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.16python3.8.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.19python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.19python3.9.____cpythontempestnotempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.19python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.19python3.9.____cpythontempesttempest.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -17,7 +19,7 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
 libnetcdf:
 - 4.7.4
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.16python3.6.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.16python3.6.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.16python3.6.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.16python3.6.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.16python3.7.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.16python3.7.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.16python3.7.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.16python3.7.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.16python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.16python3.8.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.16python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.16python3.8.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.19python3.9.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.16python3.6.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.16python3.6.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.16python3.6.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.16python3.6.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.16python3.7.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.16python3.7.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.16python3.7.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.16python3.7.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.16python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.16python3.8.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.16python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.16python3.8.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.19python3.9.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.16python3.6.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.16python3.6.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.16python3.6.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.16python3.6.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.16python3.7.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.16python3.7.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.16python3.7.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.16python3.7.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.16python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.16python3.8.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.16python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.16python3.8.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpythontempestnotempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.19python3.9.____cpythontempesttempest.yaml
@@ -17,7 +17,9 @@ hdf5:
 libblas:
 - 3.8 *netlib
 liblapack:
-- 3.8.0 *netlib
+- 3.8 *netlib
+libnetcdf:
+- 4.7.4
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "moab" %}
 {% set version = "5.2.1" %}
-{% set build = 1 %}
+{% set build = 2 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -45,7 +45,7 @@ build:
     - {{ name }} * {{ mpi_prefix }}_*
   {% endif %}
 
-  skip: true  # [win or (osx and (tempest == 'tempest')) or (linux and (tempest == 'tempest') and (mpi == 'nompi'))] 
+  skip: true  # [win or ((tempest == 'tempest') and (mpi == 'nompi'))] 
 
 requirements:
   build:


### PR DESCRIPTION
Tempest-remap is still disabled if not using MPI.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
