### PR TITLE
Rebuild for metis 5.1.0

### DIFF
--- a/.ci_support/linux_64_mpimpichnumpy1.22python3.10.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.22python3.10.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.22python3.10.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.22python3.10.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.22python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.22python3.8.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.22python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.22python3.8.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.22python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.22python3.9.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.22python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.22python3.9.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpimpichnumpy1.23python3.11.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.22python3.10.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.22python3.10.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.22python3.10.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.22python3.10.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.22python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.22python3.8.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.22python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.22python3.8.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.22python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.22python3.9.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.22python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.22python3.9.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpinompinumpy1.23python3.11.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.22python3.10.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.22python3.10.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.22python3.10.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.22python3.10.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.22python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.22python3.8.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.22python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.22python3.8.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.22python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.22python3.9.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.22python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.22python3.9.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpythontempestnotempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpythontempesttempest.yaml
+++ b/.ci_support/linux_64_mpiopenmpinumpy1.23python3.11.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ liblapack:
 libnetcdf:
 - 4.9.2
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.10.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.8.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.22python3.9.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpimpichnumpy1.23python3.11.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - mpich
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.22python3.10.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.22python3.10.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.22python3.10.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.22python3.10.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.22python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.22python3.8.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.22python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.22python3.8.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.22python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.22python3.9.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.22python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.22python3.9.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpinompinumpy1.23python3.11.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - nompi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.10.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.8.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.22python3.9.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythontempestnotempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythontempestnotempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythontempesttempest.yaml
+++ b/.ci_support/osx_64_mpiopenmpinumpy1.23python3.11.____cpythontempesttempest.yaml
@@ -23,7 +23,7 @@ libnetcdf:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 metis:
-- '5.1'
+- 5.1.0
 mpi:
 - openmpi
 mpich:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,6 +7,9 @@ tempest:
   - notempest
   - tempest
 
+metis:
+  - 5.1.0
+
 # tests are hanging with clang 14
 c_compiler_version:        # [osx and x86_64]
   - 13                     # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "moab" %}
 {% set version = "5.5.0" %}
-{% set build = 2 %}
+{% set build = 3 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

I currently can't install `moab` with `mpas_tools` because of a dependency constraint within `mpas_tools` (via `python-igraph` via `suitesparse`) that requires `metis >=5.1.0,<5.1.1.0a0`.

This seems to be related to a recent change in how `metis` gets pinned (to the patch version) but I can't say I fully understand it.  A migrator that is in the works might help but for now I need this fix to be able to install `moab` and `mpas_tools` in the same environment.